### PR TITLE
Facebook popup warning message

### DIFF
--- a/src/modules/facebook.js
+++ b/src/modules/facebook.js
@@ -48,7 +48,7 @@ hello.init({
 		name : 'Facebook',
 
 		login : function(p){
-			// The dropbox login window is a different size.
+			// The facebook login window is a different size.
 			p.options.window_width = 580;
 			p.options.window_height = 400;
 		},


### PR DESCRIPTION
This fixes the warning message from Facebook, pushing one to use their SDK.

More about the issue/fix:
http://stackoverflow.com/a/16745890

"You are using a display type of 'popup' in a large browser window or tab. For a better user experience, show this dialog with our JavaScript SDK without specifying an explicit display type. The SDK will choose the best display type for each environment. Alternatively, set height and width on your window.open() call to properly size this dialog if you have special requirements precluding you from using the SDK. This message is only visible to developers of your application."
