### PR TITLE
Updating Facebook Module to use new permission

### DIFF
--- a/src/modules/facebook.js
+++ b/src/modules/facebook.js
@@ -92,8 +92,8 @@ hello.init({
 			friends			: 'user_friends',
 			files			: 'user_photos,user_videos',
 			
-			publish_files	: 'user_photos,user_videos,publish_stream',
-			publish			: 'publish_stream',
+			publish_files	: 'user_photos,user_videos,publish_actions',
+			publish			: 'publish_actions',
 
 			// Deprecated in v2.0
 			// create_event	: 'create_event',


### PR DESCRIPTION
Updated module to use a new permission when attempting to post to the OpenGraph ( changing publish_stream to publish_actions )

See https://developers.facebook.com/blog/post/2012/04/25/streamlining-publish_stream-and-publish_actions-permissions/ for more details
