### PR TITLE
Removed the call to formatUser inside the default wrap function

### DIFF
--- a/src/modules/github.js
+++ b/src/modules/github.js
@@ -85,9 +85,6 @@ hello.init({
 				if(Object.prototype.toString.call(o) === '[object Array]'){
 					o = {data:o};
 					paging(o,headers,req);
-					for(var i=0;i<o.data.length;i++){
-						formatUser(o.data[i]);
-					}
 				}
 				return o;
 			}


### PR DESCRIPTION
Removed the call to formatUser inside the default wrap function. This was causing the name property on any item returned within a collection to be set to undefined.