### PR TITLE
Support the "auth_type" request parameter

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -309,7 +309,6 @@ hello.utils.extend( hello, {
 		p.qs = {
 			client_id	: encodeURIComponent( provider.id ),
 			response_type : response_type,
-			auth_type : opts.auth_type,
 			redirect_uri : encodeURIComponent( redirect_uri ),
 			display		: opts.display,
 			scope		: 'basic',

--- a/src/hello.js
+++ b/src/hello.js
@@ -309,6 +309,7 @@ hello.utils.extend( hello, {
 		p.qs = {
 			client_id	: encodeURIComponent( provider.id ),
 			response_type : response_type,
+			auth_type : opts.auth_type,
 			redirect_uri : encodeURIComponent( redirect_uri ),
 			display		: opts.display,
 			scope		: 'basic',

--- a/src/modules/facebook.js
+++ b/src/modules/facebook.js
@@ -51,6 +51,10 @@ hello.init({
 		name : 'Facebook',
 
 		login : function(p){
+			// Support Facebook's unique auth_type parameter
+			if(p.options.auth_type){
+				p.qs.auth_type = p.options.auth_type;
+			}
 			// The facebook login window is a different size.
 			p.options.window_width = 580;
 			p.options.window_height = 400;


### PR DESCRIPTION
Facebook Login `2.x` supports an `auth_type: rerequest` option that can redisplay the permissions dialog and prompt for any permissions that the user previously opted-out of.  The option is described at https://developers.facebook.com/docs/facebook-login/login-flow-for-web/v2.2#re-asking-declined-permissions.  Relates to issue #207.