### PR TITLE
Support multiple response_type options

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -293,12 +293,14 @@ hello.utils.extend( hello, {
 
 		//
 		// Response Type
+		// May be a comma-delimited list of multiple, complementary types
 		//
-		var response_type = provider.oauth.response_type || opts.response_type;
+		var response_type = (provider.oauth.response_type || opts.response_type).split(',');
 
 		// Fallback to token if the module hasn't defined a grant url
-		if( response_type === 'code' && !provider.oauth.grant ){
-			response_type = 'token';
+		var code_position = response_type.indexOf('code');
+		if( code_position > -1 && !provider.oauth.grant ){
+			response_type[code_position] = 'token';
 		}
 
 
@@ -308,7 +310,7 @@ hello.utils.extend( hello, {
 		//
 		p.qs = {
 			client_id	: encodeURIComponent( provider.id ),
-			response_type : response_type,
+			response_type : response_type.join(','),
 			redirect_uri : encodeURIComponent( redirect_uri ),
 			display		: opts.display,
 			scope		: 'basic',
@@ -417,7 +419,8 @@ hello.utils.extend( hello, {
 
 		// Add OAuth to state
 		// Where the service is going to take advantage of the oauth_proxy
-		if( response_type !== "token" ||
+		var token_position = response_type.indexOf('token');
+		if( token_position === -1 ||
 			parseInt(provider.oauth.version,10) < 2 ||
 			( opts.display === 'none' && provider.oauth.grant && session && session.refresh_token ) ){
 

--- a/src/hello.js
+++ b/src/hello.js
@@ -309,7 +309,7 @@ hello.utils.extend( hello, {
 		//
 		p.qs = {
 			client_id	: encodeURIComponent( provider.id ),
-			response_type : response_type,
+			response_type : encodeURIComponent( response_type ),
 			redirect_uri : encodeURIComponent( redirect_uri ),
 			display		: opts.display,
 			scope		: 'basic',

--- a/src/hello.js
+++ b/src/hello.js
@@ -293,9 +293,9 @@ hello.utils.extend( hello, {
 
 		//
 		// Response Type
-		// May be a comma-delimited list of multiple, complementary types
+		// May be a space-delimited list of multiple, complementary types
 		//
-		var response_type = (provider.oauth.response_type || opts.response_type).split(',');
+		var response_type = (provider.oauth.response_type || opts.response_type).split(' ');
 
 		// Fallback to token if the module hasn't defined a grant url
 		var code_position = response_type.indexOf('code');
@@ -310,7 +310,7 @@ hello.utils.extend( hello, {
 		//
 		p.qs = {
 			client_id	: encodeURIComponent( provider.id ),
-			response_type : response_type.join(','),
+			response_type : response_type.join(' '),
 			redirect_uri : encodeURIComponent( redirect_uri ),
 			display		: opts.display,
 			scope		: 'basic',

--- a/src/hello.js
+++ b/src/hello.js
@@ -418,7 +418,7 @@ hello.utils.extend( hello, {
 
 		// Add OAuth to state
 		// Where the service is going to take advantage of the oauth_proxy
-		if( /\btoken\b/.test(response_type) ||
+		if( !/\btoken\b/.test(response_type) ||
 			parseInt(provider.oauth.version,10) < 2 ||
 			( opts.display === 'none' && provider.oauth.grant && session && session.refresh_token ) ){
 

--- a/src/hello.js
+++ b/src/hello.js
@@ -295,12 +295,11 @@ hello.utils.extend( hello, {
 		// Response Type
 		// May be a space-delimited list of multiple, complementary types
 		//
-		var response_type = (provider.oauth.response_type || opts.response_type).split(' ');
+		var response_type = provider.oauth.response_type || opts.response_type;
 
 		// Fallback to token if the module hasn't defined a grant url
-		var code_position = response_type.indexOf('code');
-		if( code_position > -1 && !provider.oauth.grant ){
-			response_type[code_position] = 'token';
+		if( /\bcode\b/.test(response_type) && !provider.oauth.grant ){
+			response_type = response_type.replace(/\bcode\b/, 'token');
 		}
 
 
@@ -310,7 +309,7 @@ hello.utils.extend( hello, {
 		//
 		p.qs = {
 			client_id	: encodeURIComponent( provider.id ),
-			response_type : response_type.join(' '),
+			response_type : response_type,
 			redirect_uri : encodeURIComponent( redirect_uri ),
 			display		: opts.display,
 			scope		: 'basic',
@@ -419,8 +418,7 @@ hello.utils.extend( hello, {
 
 		// Add OAuth to state
 		// Where the service is going to take advantage of the oauth_proxy
-		var token_position = response_type.indexOf('token');
-		if( token_position === -1 ||
+		if( /\btoken\b/.test(response_type) ||
 			parseInt(provider.oauth.version,10) < 2 ||
 			( opts.display === 'none' && provider.oauth.grant && session && session.refresh_token ) ){
 


### PR DESCRIPTION
Facebook Login `2.x` supports a `response_type` of `granted_scopes` that can be combined with the other `response_type` options in a comma-delimited list.  Current checks of the `response_type` in `hello.js` are not expecting multiple options, so this update will switch from string to array logic.  The `granted_scopes` option is described at https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/v2.2#login.  Relates to issue #207.