### PR TITLE
URL-encode individual scopes

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -369,9 +369,8 @@ hello.utils.extend( hello, {
 
 		}).replace(/[,\s]+/ig, ',');
 
-		// remove duplication and empty spaces
-		p.qs.scope = utils.unique(p.qs.scope.split(/,+/)).join( provider.scope_delim || ',');
-
+		// remove duplication and empty spaces; encode individual scopes
+		p.qs.scope = utils.unique(p.qs.scope.split(/,+/)).map(encodeURIComponent).join( provider.scope_delim || ',');
 
 
 


### PR DESCRIPTION
URL-encode individual scopes as they may contain invalid characters.

I noticed there are some tests and apparent reasoning around this functionality, but this change doesn't seem to break any of them...