### PR TITLE
Refactor name processing

### DIFF
--- a/src/modules/flickr.js
+++ b/src/modules/flickr.js
@@ -35,8 +35,8 @@
 						if (o.realname) {
 							o.name = o.realname._content;
 							var m = o.name.split(' ');
-							o.first_name = m[0];
-							o.last_name = m[1];
+							o.first_name = m.shift();
+							o.last_name = m.join(' ');
 						}
 
 						o.thumbnail = getBuddyIcon(o, 'l');


### PR DESCRIPTION
Current implementation assumes that a name is only "John Doe" or "Mary Jane", however should a user with a name of "John Joseph Doe" come along, `last_name` would be "Joseph" and not "Doe". 

The proposed change will change `last_name` to read "Joseph Doe"