### PR TITLE
With Google Contacts v3, a missing gd:etag means there's no image

### DIFF
--- a/src/modules/google.js
+++ b/src/modules/google.js
@@ -268,7 +268,7 @@
 
 				if (a.link) {
 					var pic = (a.link.length > 0) ? a.link[0].href + '?access_token=' + token : null;
-					if (pic) {
+					if (pic && a.link[0].gd$etag) {
 						a.picture = pic;
 						a.thumbnail = pic;
 					}


### PR DESCRIPTION
According to this:

https://developers.google.com/google-apps/contacts/v3/#retrieving_a_contacts_photo