### PR TITLE
Fix images for google contacts

### DIFF
--- a/src/modules/google.js
+++ b/src/modules/google.js
@@ -267,7 +267,7 @@
 				}
 
 				if (a.link) {
-					var pic = (a.link.length > 0) ? a.link[0].href + '?access_token=' + token : null;
+					var pic = (a.link.length > 0) ? a.link[0].href + '&access_token=' + token : null;
 					if (pic) {
 						a.picture = pic;
 						a.thumbnail = pic;


### PR DESCRIPTION
Since v=3.0 is included in the request, it also comes back as a query parameter in image URLs. So the access_token is no longer the first parameter.