### PR TITLE
fix crash when cloning objects with array of objects

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -2078,7 +2078,7 @@ hello.utils.extend(hello.utils, {
 
 		if (Array.isArray(obj)) {
 			// Clone each item in the array
-			return obj.map(this.clone);
+			return obj.map(this.clone.bind(this));
 		}
 
 		// But does clone everything else.

--- a/tests/specs/unit/utils/clone.js
+++ b/tests/specs/unit/utils/clone.js
@@ -99,6 +99,24 @@ define([], function() {
 
 		});
 
+		it('should clone arrays in objects', function() {
+			var orig = {
+				foo: 'bar',
+				arr: [
+					{
+						a: 'b',
+						c: 'd'
+					},
+					{
+						a: '1',
+						c: '3'
+					}
+				]
+			};
+			var clone = utils.clone(orig);
+
+			expect(clone).to.be.eql(orig).and.to.not.be.equal(orig);
+		});
 	});
 
 });


### PR DESCRIPTION
Hi,

I have a case where I need to send an object containing array of objects as a post. The clone function is crashing since does not get the this correctly. Would be great to merge this into a new release as I had to overwrite the clone function in my project to work correctly.

Thanks
Petrica