### PR TITLE
Added a check for Yahoo contacts with no First or Last Name

### DIFF
--- a/src/modules/yahoo.js
+++ b/src/modules/yahoo.js
@@ -117,7 +117,7 @@
 
 	function formatFriend(contact) {
 		contact.id = null;
-		contact.fields.forEach(function(field) {
+		(contact.fields || []).forEach(function(field) {
 			if (field.type === 'email') {
 				contact.email = field.value;
 			}


### PR DESCRIPTION
hello.js would break at line 120 in yahoo.js because contacts with no First or Last names will not have a `contact.fields` property (which in turn fails the `forEach`).

I am still fairly new to contributing to Github, so please excuse me if I did anything incorrectly. I simply wrapped formatFriend in a conditional `if (typeof contact.fields !== 'undefined' && contact.fields.length > 0) {` and then ran `grunt`. Please let me know if I need to fix or missed anything.

Thanks for the library! 