### PR TITLE
Fallback session issue fixed

### DIFF
--- a/dist/hello.js
+++ b/dist/hello.js
@@ -766,13 +766,13 @@ hello.utils.extend(hello.utils, {
 	store: (function() {
 
 		var a = ['localStorage', 'sessionStorage'];
-		var i = 0;
+		var i = -1;
 		var prefix = 'test';
 
 		// Set LocalStorage
 		var localStorage;
 
-		while (a[i++]) {
+		while (a[++i]) {
 			try {
 				// In Chrome with cookies blocked, calling localStorage throws an error
 				localStorage = window[a[i]];

--- a/src/hello.js
+++ b/src/hello.js
@@ -613,13 +613,13 @@ hello.utils.extend(hello.utils, {
 	store: (function() {
 
 		var a = ['localStorage', 'sessionStorage'];
-		var i = 0;
+		var i = -1;
 		var prefix = 'test';
 
 		// Set LocalStorage
 		var localStorage;
 
-		while (a[i++]) {
+		while (a[++i]) {
 			try {
 				// In Chrome with cookies blocked, calling localStorage throws an error
 				localStorage = window[a[i]];


### PR DESCRIPTION
Wrong logic of implementing fallback storage i.e sessionStorage is fixed. Previously it was saving directly to sessionStorage whereas it should have checked the availability of localStorage first. And if localstorage is not available only then it needs to store into sessionStorage.