### PR TITLE
Fixed issue of undefined hello object when using chromeapp

### DIFF
--- a/src/hello.chromeapp.js
+++ b/src/hello.chromeapp.js
@@ -36,7 +36,7 @@ if (typeof chrome === 'object' && typeof chrome.identity === 'object' && chrome.
 		var _cache = {};
 		chrome.storage.local.get('hello', function(r) {
 			// Update the cache
-			_cache = r.hello;
+			_cache = r.hello || {};
 		});
 
 		hello.utils.store = function(name, value) {


### PR DESCRIPTION
When there is no hello object in localStorage "_cache" becomes undefined whereas it needs to be an empty object.