### PR TITLE
Fix dead ./modules link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,7 +832,7 @@ The first parameter of a failed request to the *errorHandler* may be either *boo
 
 
 ## Extending the services
-Services are added to HelloJS as "modules" for more information about creating your own modules and examples, go to [Modules](https://adodson.com/hello.js/modules)
+Services are added to HelloJS as "modules" for more information about creating your own modules and examples, go to [Modules](./modules.md)
 
 ## OAuth Proxy
 

--- a/README.md
+++ b/README.md
@@ -832,7 +832,7 @@ The first parameter of a failed request to the *errorHandler* may be either *boo
 
 
 ## Extending the services
-Services are added to HelloJS as "modules" for more information about creating your own modules and examples, go to [Modules](./modules)
+Services are added to HelloJS as "modules" for more information about creating your own modules and examples, go to [Modules](https://adodson.com/hello.js/modules)
 
 ## OAuth Proxy
 


### PR DESCRIPTION
Fixed link that pointed to modules, moved it to the
modules page in the documentation, which is much
more helpful.