### PR TITLE
Fixed url resolving in IE compatibility view mode

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -845,7 +845,7 @@ hello.utils.extend(hello.utils, {
 		else {
 			var a = document.createElement('a');
 			a.href = path;
-			return a;
+			return a.cloneNode(false);
 		}
 	},
 


### PR DESCRIPTION
When working in IE compatibility view mode, simply reading href property is not enough to get full url. It just returns that it was assigned to.