### PR TITLE
workaround to fix unexpected return from fb for end point 'me/picture'

### DIFF
--- a/src/modules/facebook.js
+++ b/src/modules/facebook.js
@@ -172,6 +172,13 @@
 
 		if (o && 'data' in o) {
 			var token = req.query.access_token;
+
+			if (!(o.data instanceof Array)) {
+				var data = o.data;
+				delete o.data;
+				o.data = [data];
+			}
+
 			o.data.forEach(function(d) {
 
 				if (d.picture) {


### PR DESCRIPTION
Tested with grunt CLI.
Tested with Safari, Chrome and Firefox.
Not sure what is the best way to build the distribution for such a small update, so I let you do it.