### PR TITLE
Given popup dimension overrides does not work

### DIFF
--- a/src/modules/facebook.js
+++ b/src/modules/facebook.js
@@ -43,10 +43,6 @@
 				if (p.options.force) {
 					p.qs.auth_type = 'reauthenticate';
 				}
-
-				// The facebook login window is a different size.
-				p.options.popup.width = 580;
-				p.options.popup.height = 400;
 			},
 
 			logout: function(callback, options) {


### PR DESCRIPTION
Overriding the optionized popup values went wrong. The given values are not as big enough. Facebook tells to make the popup wider and higher.