### PR TITLE
Link to raw files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Here are some more demos...
 
 ## Install
 
-Download: [HelloJS](dist/hello.all.js) | [HelloJS (minified)](dist/hello.all.min.js)
+Download: [HelloJS](https://github.com/MrSwitch/hello.js/raw/master/dist/hello.all.js) | [HelloJS (minified)](https://github.com/MrSwitch/hello.js/raw/master/dist/hello.all.min.js)
 
 Compiled source, which combines all of the modules, can be obtained from [GitHub](https://github.com/MrSwitch/hello.js/tree/master/dist), and source files can be found in [Source](https://github.com/MrSwitch/hello.js/tree/master/src).
 


### PR DESCRIPTION
Given these are download links, I think it makes sense to link to the raw file so it's possible to do things like "Save-as" etc.