### PR TITLE
Update Google endpoints

### DIFF
--- a/src/modules/google.js
+++ b/src/modules/google.js
@@ -11,8 +11,8 @@
 			// See: http://code.google.com/apis/accounts/docs/OAuth2UserAgent.html
 			oauth: {
 				version: 2,
-				auth: 'https://accounts.google.com/o/oauth2/auth',
-				grant: 'https://accounts.google.com/o/oauth2/token'
+				auth: 'https://accounts.google.com/o/oauth2/v2/auth',
+				grant: 'https://www.googleapis.com/oauth2/v4/token'
 			},
 
 			// Authorization scopes

--- a/src/modules/google.js
+++ b/src/modules/google.js
@@ -41,6 +41,9 @@
 					// Let's set this to an offline access to return a refresh_token
 					p.qs.access_type = 'offline';
 				}
+				else if (p.qs.response_type.indexOf('id_token') > -1) {
+					p.qs.nonce = parseInt(Math.random() * 1e12, 10).toString(36);
+				}
 
 				// Reauthenticate
 				// https://developers.google.com/identity/protocols/


### PR DESCRIPTION
I ran into an issue where the old endpoints would return
tokens with missing data when using the `id_token` response
type. I pulled the newer versions from:

https://accounts.google.com/.well-known/openid-configuration

With the newer Google endpoints, `id_token` response
types require a `nonce` paramenter. This may not be
necessary, because it doesn't look like OpenID Connect
is officially supported here.