### PR TITLE
Try to decode state param if json parser fails

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -1327,7 +1327,14 @@ hello.utils.extend(hello.utils, {
 				_this.extend(p, a);
 			}
 			catch (e) {
-				console.error('Could not decode state parameter');
+				var stateDecoded = decodeURIComponent(p.state);
+				try {
+					var b = JSON.parse(stateDecoded);
+					_this.extend(p, b);
+				}
+				catch (e) {
+					console.error('Could not decode state parameter');
+				}
 			}
 
 			// Access_token?


### PR DESCRIPTION
If JSON.parse fails to parse the state param, hellojs should try to decode the param first and try to parse it again, before throwing an error. Using https://apereo.github.io/cas/development/installation/OAuth-OpenId-Authentication.html as OAuth server URLencodes the state param and who knows which one else.