### PR TITLE
Updated LinkedIn Authorization URLs, no longer Legacy urls

### DIFF
--- a/dist/hello.all.js
+++ b/dist/hello.all.js
@@ -4874,8 +4874,8 @@ if (typeof chrome === 'object' && typeof chrome.identity === 'object' && chrome.
 			oauth: {
 				version: 2,
 				response_type: 'code',
-				auth: 'https://www.linkedin.com/uas/oauth2/authorization',
-				grant: 'https://www.linkedin.com/uas/oauth2/accessToken'
+				auth: 'https://www.linkedin.com/oauth/v2/authorization',
+				grant: 'https://www.linkedin.com/oauth/v2/accessToken'
 			},
 
 			// Refresh the access_token once expired

--- a/src/modules/linkedin.js
+++ b/src/modules/linkedin.js
@@ -7,8 +7,8 @@
 			oauth: {
 				version: 2,
 				response_type: 'code',
-				auth: 'https://www.linkedin.com/uas/oauth2/authorization',
-				grant: 'https://www.linkedin.com/uas/oauth2/accessToken'
+				auth: 'https://www.linkedin.com/oauth/v2/authorization',
+				grant: 'https://www.linkedin.com/oauth/v2/accessToken'
 			},
 
 			// Refresh the access_token once expired


### PR DESCRIPTION
I noticed that the URLS for the linkedIn Oauth are considered legacy per here:
https://developer.linkedin.com/docs/oauth2-legacy

I simply replaced the links with their current modern counterpart per here:
https://developer.linkedin.com/docs/oauth2