### PR TITLE
Update .api() documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,18 @@ hello.api([path], [method], [data], [callback(json)]).then(successHandler, error
 		<td>null</td>
 	</tr>
 	<tr>
+		<td>query</td>
+		<td><i>object</i></td>
+		<td>
+			<code>{name:<q>Hello</q>}</code>
+		</td>
+		<td>HTTP query string parameters.</td>
+		<td>
+			<em>optional</em>
+		</td>
+		<td>null</td>
+	</tr>
+	<tr>
 		<td>method</td>
 		<td>
 			<q>get</q>,
@@ -594,6 +606,22 @@ hello.api([path], [method], [data], [callback(json)]).then(successHandler, error
 		</td>
 	</tr>
 	<tr>
+		<td>timeout</td>
+		<td><i>integer</i></td>
+		<td>
+			<code>3000</code> = 3 seconds.
+		</td>
+		<td>
+			Wait <em>milliseconds</em> before resolving the Promise with a reject.
+		</td>
+		<td>
+			<em>optional</em>
+		</td>
+		<td>
+			<em>60000</em>
+		</td>
+	</tr>
+	<tr>
 		<td>callback</td>
 		<td><i>function</i></td>
 		<td>
@@ -611,22 +639,6 @@ hello.api([path], [method], [data], [callback(json)]).then(successHandler, error
 	</tr>
 	<tr>
 		<td colspan='6'>More options (below) require putting the options into a 'key'=>'value' hash. I.e. <code>hello(network).api(options)</code>
-		</td>
-	</tr>
-	<tr>
-		<td>timeout</td>
-		<td><i>integer</i></td>
-		<td>
-			<code>3000</code> = 3 seconds.
-		</td>
-		<td>
-			Wait <em>milliseconds</em> before resolving the Promise with a reject.
-		</td>
-		<td>
-			<em>optional</em>
-		</td>
-		<td>
-			<em>60000</em>
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
As far as I understand the code on this line:

https://github.com/MrSwitch/hello.js/blob/v1.15.1/src/hello.js#L1627

the list of parameters is different from the documentation, and `query` and `timeout` can be passed as parameters. I ran into this when updating TypeScript type definitions.

I'm not sure if these are intentionally left out. I understand that `data` is merged into the `query` parameter unless `method` is provided (and is not `get` or `delete`), so there is no functional difference between what's documented and how the method behaves.