### PR TITLE
Documentation: oauth.response_type in module init

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -164,6 +164,11 @@ Modules are loaded into HelloJS using the hello.init() method, with a JSON objec
 							<td>url</td>
 							<td>Path to get the Access token, OAuth2 only</td>
 						</tr>
+						<tr>
+							<td>response_type</td>
+							<td>string</td>
+							<td>Implicit (token) or Explicit (code) Grant flow</td>
+						</tr>
 					</tbody>
 				</table>
 			</td>


### PR DESCRIPTION
Add missing oauth option response_type in module documentation.

This is used in some of the built-in modules, for example:
https://github.com/MrSwitch/hello.js/blob/v1.15.1/src/modules/box.js