### PR TITLE
Check for Google photo entries before parsing #550

### DIFF
--- a/src/modules/google.js
+++ b/src/modules/google.js
@@ -219,8 +219,12 @@
 	}
 
 	function formatPhotos(o) {
-		o.data = o.feed.entry.map(formatEntry);
-		delete o.feed;
+		if ('feed' in o) {
+			o.data = 'entry' in o.feed ? o.feed.entry.map(formatEntry) : [];
+			delete o.feed;
+		}
+
+		return o;
 	}
 
 	// Google has a horrible JSON API


### PR DESCRIPTION
Fixes https://github.com/MrSwitch/hello.js/issues/550 by checking if there are entries in the response, since it will be absent when there are no photos available. Will return an empty data array to stay consistent with the other responses. 