### PR TITLE
URI encode scope query string parameter

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -319,7 +319,7 @@ hello.utils.extend(hello, {
 		scope = utils.unique(scope).filter(filterEmpty);
 
 		// Join with the expected scope delimiter into a string
-		p.qs.scope = scope.join(provider.scope_delim || ',');
+		p.qs.scope = encodeURIComponent(scope.join(provider.scope_delim || ','));
 
 		// Is the user already signed in with the appropriate scopes, valid access_token?
 		if (opts.force === false) {


### PR DESCRIPTION
Encode the scope query string parameter for providers such as Google that have full URLs with spaces in their scope.