### PR TITLE
Fixed javascript error when parameter is not a string on IE 11. #365

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -213,13 +213,13 @@ hello.utils.extend(hello, {
 		var provider = _this.services[p.network];
 
 		// Create a global listener to capture events triggered out of scope
-		var callbackId = utils.globalEvent(function(str) {
+		var callbackId = utils.globalEvent(function(obj) {
 
 			// The responseHandler returns a string, lets save this locally
-			var obj;
-
-			if (str) {
-				obj = JSON.parse(str);
+			if (obj) {
+				if (typeof(obj) == "string") {
+					obj = JSON.parse(obj);
+				}
 			}
 			else {
 				obj = error('cancelled', 'The authentication was not completed');

--- a/src/hello.js
+++ b/src/hello.js
@@ -217,7 +217,7 @@ hello.utils.extend(hello, {
 
 			// The responseHandler returns a string, lets save this locally
 			if (obj) {
-				if (typeof(obj) == "string") {
+				if (typeof (obj) == 'string') {
 					obj = JSON.parse(obj);
 				}
 			}


### PR DESCRIPTION
This pull request is to fix an issue with Internet Explorer 11, where it would return `SynxtaxError: Invalid character`.