### PR TITLE
Updating Google prompt property name and value when forcing a re-authentication

### DIFF
--- a/src/modules/google.js
+++ b/src/modules/google.js
@@ -47,7 +47,7 @@
 				// Reauthenticate
 				// https://developers.google.com/identity/protocols/
 				if (p.options.force) {
-					p.qs.approval_prompt = 'force';
+					p.qs.prompt = 'consent';
 				}
 			},
 


### PR DESCRIPTION
…ntication

- updating for the new property to force a re-authentication
- the property approval_prompt=force is now outdated, the correct property is prompt=consent