### PR TITLE
fix(redirects): lock down redirect attempts, fixes #619

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -1413,7 +1413,14 @@ hello.utils.extend(hello.utils, {
 
 		function isValidUrl(url) {
 			var regexp = /^https?:/;
-			return regexp.test(url);
+			return regexp.test(url)
+
+				// If `HELLOJS_REDIRECT_URL` is defined in the window context, validate that the URL matches it.
+				&& (
+					!Object.prototype.hasOwnProperty.call(window, 'HELLOJS_REDIRECT_URL')
+					||
+					url.match(window.HELLOJS_REDIRECT_URL)
+				);
 		}
 
 		// Trigger a callback to authenticate


### PR DESCRIPTION
Fixes #619 
Closes #621

Place a constant on `redirect.html` page, before including `hello.js`

Something like ...
```js
// Scope any redirect URL's to the current domain... this would prevent `page_uri` being used to redirect to another domain
var HELLOJS_REDIRECT_URL = window.location.origin;

// Disable any redirect
var HELLOJS_REDIRECT_URL = false;
```

Hellojs could then simply check `!Object.prototype.hasOwnProperty.call(window, 'HELLOJS_REDIRECT_URL') || page_uri.match(window.HELLOJS_REDIRECT_URL)`,  before allowing any redirect to occur.
