### PR TITLE
Use base 64 encoding instead of uri encoding of state param for yahoo

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -375,7 +375,14 @@ hello.utils.extend(hello, {
 		}
 
 		// Convert state to a string
-		p.qs.state = encodeURIComponent(JSON.stringify(p.qs.state));
+		// Yahoo requires the state param to be base 64 encoded. 
+		// URI encoding somehow makes yahoo unhappy and auth fails at consent page.
+		if(p.network === "Yahoo") {
+			p.qs.state = window.btoa(JSON.stringify(p.qs.state));
+		}
+		else {
+			p.qs.state = encodeURIComponent(JSON.stringify(p.qs.state));
+		}
 
 		// URL
 		if (parseInt(provider.oauth.version, 10) === 1) {

--- a/src/hello.js
+++ b/src/hello.js
@@ -375,9 +375,9 @@ hello.utils.extend(hello, {
 		}
 
 		// Convert state to a string
-		// Yahoo requires the state param to be base 64 encoded. 
-		// URI encoding somehow makes yahoo unhappy and auth fails at consent page.
-		if(p.network === "Yahoo") {
+		// Yahoo requires the state param to be base 64 encoded and the flag base64_state is set to true for Yahoo.
+		// Else uri encoding is used for all the other providers.
+		if (provider.oauth.base64_state) {
 			p.qs.state = window.btoa(JSON.stringify(p.qs.state));
 		}
 		else {

--- a/src/hello.js
+++ b/src/hello.js
@@ -375,8 +375,6 @@ hello.utils.extend(hello, {
 		}
 
 		// Convert state to a string
-		// Yahoo requires the state param to be base 64 encoded and the flag base64_state is set to true for Yahoo.
-		// Else uri encoding is used for all the other providers.
 		if (provider.oauth.base64_state) {
 			p.qs.state = window.btoa(JSON.stringify(p.qs.state));
 		}

--- a/src/modules/yahoo.js
+++ b/src/modules/yahoo.js
@@ -10,6 +10,8 @@
 				auth: 'https://api.login.yahoo.com/oauth/v2/request_auth',
 				request: 'https://api.login.yahoo.com/oauth/v2/get_request_token',
 				token: 'https://api.login.yahoo.com/oauth/v2/get_token',
+				// Yahoo requires the state param to be base 64 encoded, hence the flag base64_state is set to true for Yahoo.
+				// Else uri encoding is used for all the other providers.
 				base64_state: true
 			},
 

--- a/src/modules/yahoo.js
+++ b/src/modules/yahoo.js
@@ -9,7 +9,8 @@
 				version: '1.0a',
 				auth: 'https://api.login.yahoo.com/oauth/v2/request_auth',
 				request: 'https://api.login.yahoo.com/oauth/v2/get_request_token',
-				token: 'https://api.login.yahoo.com/oauth/v2/get_token'
+				token: 'https://api.login.yahoo.com/oauth/v2/get_token',
+				base64_state: true
 			},
 
 			// Login handler

--- a/tests/specs/unit/core/hello.login.js
+++ b/tests/specs/unit/core/hello.login.js
@@ -154,53 +154,7 @@ describe('hello.login', function() {
 			hello.login('testable', {redirect_uri: REDIRECT_URI});
 		});
 
-		it('yahoo : should base 64 encode the state by default, if oauth option is not overridden', function(done) {
-
-			var spy = sinon.spy(function(url, name, optins) {
-				// The url should not contain uri encoded characters
-				expect(url).to.not.contain('state=%7B%22');
-
-				done();
-			});
-
-			utils.popup = spy;
-
-			hello.login('yahoo');
-		});
-
-		it('yahoo : should base 64 encode the state if base64_state is true', function(done) {
-
-			hello.services.yahoo.oauth.base64_state = true;
-
-			var spy = sinon.spy(function(url, name, optins) {
-				// The url should not contain uri encoded characters
-				expect(url).to.not.contain('state=%7B%22');
-
-				done();
-			});
-
-			utils.popup = spy;
-
-			hello.login('yahoo');
-		});
-
-		it('yahoo : should uri encode the state if base64_state is false', function(done) {
-
-			hello.services.yahoo.oauth.base64_state = false;
-
-			var spy = sinon.spy(function(url, name, optins) {
-				// The url should contain uri encoded characters
-				expect(url).to.contain('state=%7B%22');
-
-				done();
-			});
-
-			utils.popup = spy;
-
-			hello.login('yahoo');
-		});
-
-		it('non yahoo : should base 64 encode the state if oauth.base64_state is true', function(done) {
+		it('should base 64 encode the state if oauth.base64_state is true', function(done) {
 
 			hello.services.testable.oauth.base64_state = true;
 
@@ -216,7 +170,7 @@ describe('hello.login', function() {
 			hello.login('testable');
 		});
 
-		it('non yahoo : should uri encode the state if oauth.base64_state is false', function(done) {
+		it('should uri encode the state if oauth.base64_state is false', function(done) {
 
 			hello.services.testable.oauth.base64_state = false;
 
@@ -232,7 +186,7 @@ describe('hello.login', function() {
 			hello.login('testable');
 		});
 
-		it('non yahoo : should uri encode the state by default', function(done) {
+		it('should uri encode the state by default', function(done) {
 
 			var spy = sinon.spy(function(url, name, optins) {
 				// The url should contain uri encoded characters

--- a/tests/specs/unit/core/hello.login.js
+++ b/tests/specs/unit/core/hello.login.js
@@ -32,7 +32,8 @@ describe('hello.login', function() {
 		// Add a network
 		hello.init({
 			testable: testable,
-			second: second
+			second: second,
+			yahoo: 'test_client_id'
 		});
 
 	});
@@ -145,6 +146,82 @@ describe('hello.login', function() {
 
 				expect(url).to.not.contain(REDIRECT_URI);
 				expect(url).to.contain(encodeURIComponent(REDIRECT_URI));
+
+				done();
+			});
+
+			utils.popup = spy;
+
+			hello.login('testable', {redirect_uri: REDIRECT_URI});
+		});
+
+		it('should base 64 encode the state for yahoo by default, if oauth option is not overridden', function(done) {
+
+			var REDIRECT_URI = 'http://dummydomain.com/?breakdown';
+
+			var spy = sinon.spy(function(url, name, optins) {
+
+				expect(url).to.not.contain(REDIRECT_URI);
+				// The url should not contain uri encoded characters
+				expect(url).to.not.contain('state=%7B%22');
+
+				done();
+			});
+
+			utils.popup = spy;
+
+			hello.login('yahoo', {redirect_uri: REDIRECT_URI});
+		});
+
+		it('should base 64 encode the state if oauth.base64_state is true', function(done) {
+
+			hello.services.testable.oauth.base64_state = true;
+
+			var REDIRECT_URI = 'http://dummydomain.com/?breakdown';
+
+			var spy = sinon.spy(function(url, name, optins) {
+
+				expect(url).to.not.contain(REDIRECT_URI);
+				// The url should not contain uri encoded characters
+				expect(url).to.not.contain('state=%7B%22');
+
+				done();
+			});
+
+			utils.popup = spy;
+
+			hello.login('testable', {redirect_uri: REDIRECT_URI});
+		});
+
+		it('should uri encode the state if oauth.base64_state is false', function(done) {
+
+			hello.services.testable.oauth.base64_state = false;
+
+			var REDIRECT_URI = 'http://dummydomain.com/?breakdown';
+
+			var spy = sinon.spy(function(url, name, optins) {
+
+				expect(url).to.not.contain(REDIRECT_URI);
+				// The url should contain uri encoded characters
+				expect(url).to.contain('state=%7B%22');
+
+				done();
+			});
+
+			utils.popup = spy;
+
+			hello.login('testable', {redirect_uri: REDIRECT_URI});
+		});
+
+		it('should uri encode the state if oauth.base64_state is not defined', function(done) {
+
+			var REDIRECT_URI = 'http://dummydomain.com/?breakdown';
+
+			var spy = sinon.spy(function(url, name, optins) {
+
+				expect(url).to.not.contain(REDIRECT_URI);
+				// The url should contain uri encoded characters
+				expect(url).to.contain('state=%7B%22');
 
 				done();
 			});

--- a/tests/specs/unit/core/hello.login.js
+++ b/tests/specs/unit/core/hello.login.js
@@ -32,8 +32,7 @@ describe('hello.login', function() {
 		// Add a network
 		hello.init({
 			testable: testable,
-			second: second,
-			yahoo: 'test_client_id'
+			second: second
 		});
 
 	});
@@ -155,13 +154,9 @@ describe('hello.login', function() {
 			hello.login('testable', {redirect_uri: REDIRECT_URI});
 		});
 
-		it('should base 64 encode the state for yahoo by default, if oauth option is not overridden', function(done) {
-
-			var REDIRECT_URI = 'http://dummydomain.com/?breakdown';
+		it('yahoo : should base 64 encode the state by default, if oauth option is not overridden', function(done) {
 
 			var spy = sinon.spy(function(url, name, optins) {
-
-				expect(url).to.not.contain(REDIRECT_URI);
 				// The url should not contain uri encoded characters
 				expect(url).to.not.contain('state=%7B%22');
 
@@ -170,18 +165,46 @@ describe('hello.login', function() {
 
 			utils.popup = spy;
 
-			hello.login('yahoo', {redirect_uri: REDIRECT_URI});
+			hello.login('yahoo');
 		});
 
-		it('should base 64 encode the state if oauth.base64_state is true', function(done) {
+		it('yahoo : should base 64 encode the state if base64_state is true', function(done) {
+
+			hello.services.yahoo.oauth.base64_state = true;
+
+			var spy = sinon.spy(function(url, name, optins) {
+				// The url should not contain uri encoded characters
+				expect(url).to.not.contain('state=%7B%22');
+
+				done();
+			});
+
+			utils.popup = spy;
+
+			hello.login('yahoo');
+		});
+
+		it('yahoo : should uri encode the state if base64_state is false', function(done) {
+
+			hello.services.yahoo.oauth.base64_state = false;
+
+			var spy = sinon.spy(function(url, name, optins) {
+				// The url should contain uri encoded characters
+				expect(url).to.contain('state=%7B%22');
+
+				done();
+			});
+
+			utils.popup = spy;
+
+			hello.login('yahoo');
+		});
+
+		it('non yahoo : should base 64 encode the state if oauth.base64_state is true', function(done) {
 
 			hello.services.testable.oauth.base64_state = true;
 
-			var REDIRECT_URI = 'http://dummydomain.com/?breakdown';
-
 			var spy = sinon.spy(function(url, name, optins) {
-
-				expect(url).to.not.contain(REDIRECT_URI);
 				// The url should not contain uri encoded characters
 				expect(url).to.not.contain('state=%7B%22');
 
@@ -190,18 +213,14 @@ describe('hello.login', function() {
 
 			utils.popup = spy;
 
-			hello.login('testable', {redirect_uri: REDIRECT_URI});
+			hello.login('testable');
 		});
 
-		it('should uri encode the state if oauth.base64_state is false', function(done) {
+		it('non yahoo : should uri encode the state if oauth.base64_state is false', function(done) {
 
 			hello.services.testable.oauth.base64_state = false;
 
-			var REDIRECT_URI = 'http://dummydomain.com/?breakdown';
-
 			var spy = sinon.spy(function(url, name, optins) {
-
-				expect(url).to.not.contain(REDIRECT_URI);
 				// The url should contain uri encoded characters
 				expect(url).to.contain('state=%7B%22');
 
@@ -210,16 +229,12 @@ describe('hello.login', function() {
 
 			utils.popup = spy;
 
-			hello.login('testable', {redirect_uri: REDIRECT_URI});
+			hello.login('testable');
 		});
 
-		it('should uri encode the state if oauth.base64_state is not defined', function(done) {
-
-			var REDIRECT_URI = 'http://dummydomain.com/?breakdown';
+		it('non yahoo : should uri encode the state by default', function(done) {
 
 			var spy = sinon.spy(function(url, name, optins) {
-
-				expect(url).to.not.contain(REDIRECT_URI);
 				// The url should contain uri encoded characters
 				expect(url).to.contain('state=%7B%22');
 
@@ -228,7 +243,7 @@ describe('hello.login', function() {
 
 			utils.popup = spy;
 
-			hello.login('testable', {redirect_uri: REDIRECT_URI});
+			hello.login('testable');
 		});
 
 		it('should pass through unknown scopes defined in `options.scope`', function(done) {


### PR DESCRIPTION
Yahoo expects base 64 encoding of state param and somehow fails at the consent page if URI encoding is used. This PR intends to change the encoding for Yahoo network. It retains the original behavior for other networks.

For all clients using hellojs for yahoo (not sure if there are any as it seemed busted for yahoo), one will have to base 64 decode the state param before it can be parsed to extract the state param attributes.