### PR TITLE
Decode back possible Base64-encoded state in responseHandler

### DIFF
--- a/src/hello.js
+++ b/src/hello.js
@@ -1303,6 +1303,14 @@ hello.utils.extend(hello.utils, {
 		// Is this an auth relay message which needs to call the proxy?
 		p = _this.param(location.search);
 
+		// Decode back possible Base64-encoded state
+		if (p && p.state) {
+			const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
+			if (base64regex.test(p.state)) {
+				p.state = window.atob(p.state);
+			}
+		}
+
 		// OAuth2 or OAuth1 server response?
 		if (p && p.state && (p.code || p.oauth_token)) {
 


### PR DESCRIPTION
In PR #658 the property base64_state was added, to force the state param to be base64-encoded instead of URI encoded.

That makes the state impossible to decode when the flow returns to the calling page, so we detect if the returned state is in base64 and decode it accordingly if so, first of all.